### PR TITLE
Add minimal Rust IdP prototype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "idp"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.7"
+tokio = { version = "1.37", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+jsonwebtoken = "8"
+clap = { version = "4", features = ["derive"] }
+uuid = { version = "1" }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # ChatGPTGeneratedCode
+
+This repository contains a prototype Rust Identity Provider (IdP) optimized for machine-to-machine authentication. The project demonstrates a minimal HTTP server that issues JWTs to registered service accounts.
+
+## Building
+
+Ensure you have Rust and Cargo installed. Then build the project:
+
+```bash
+cargo build --release
+```
+
+## Running the Server
+
+Create at least one service account and start the server:
+
+```bash
+# create a new account
+cargo run --release -- create-account --accounts accounts.json
+
+# run the server
+cargo run --release -- server --accounts accounts.json --addr 127.0.0.1:3000
+```
+
+The server exposes a `POST /token` endpoint that accepts JSON credentials:
+
+```json
+{ "client_id": "<id>", "client_secret": "<secret>" }
+```
+
+If the credentials match, the server returns a JWT.
+

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,51 @@
+# Architecture Overview
+
+This document describes the core components and data flow of the proposed Rust-based Identity Provider (IdP) optimized for non-human identities.
+
+## Components
+
+1. **HTTP API Layer**
+   - Built with Axum (or Actix Web) running on Tokio async runtime for performance.
+   - Exposes RESTful endpoints for token issuance, validation, and management of service accounts.
+   - Handles JSON/Web token requests and responses.
+
+2. **Authentication & Authorization Module**
+   - Implements OAuth2 client credentials flow and custom service account login.
+   - Generates signed JWTs for agents with configurable lifetimes.
+   - Supports role-based permissions stored in the identity database.
+
+3. **Identity Store**
+   - Backed by PostgreSQL for reliability; SQLite may be used during development.
+   - Stores service account credentials, API keys, and metadata about agent roles.
+   - Provides a query layer for fast lookups with optional caching.
+
+4. **Token Service**
+   - Issues, validates, and revokes JWTs.
+   - Utilizes rotating signing keys and secure random generation.
+   - Caches verified keys to reduce latency during validation.
+
+5. **Observability & Monitoring**
+   - Metrics exported via Prometheus and structured logs for auditing.
+   - Tracing spans around key operations to identify latency issues.
+
+6. **CLI & SDK**
+   - Command-line tools for managing identities and tokens.
+   - Reference SDKs (Rust, Python, etc.) for integrating agents.
+
+## Data Flow
+1. An agent authenticates using a registered client ID and secret.
+2. The HTTP API validates the credentials against the Identity Store.
+3. Upon success, the Token Service generates a JWT with roles/permissions embedded.
+4. The agent receives the token and uses it to access protected resources.
+5. Auditing and metrics are recorded throughout the process.
+
+## Security Considerations
+- All secrets are stored encrypted at rest.
+- TLS is mandatory for all network communication.
+- Rate limiting and anomaly detection guard against abuse.
+
+## Performance Strategies
+- Use asynchronous I/O throughout to minimize blocking.
+- Employ connection pooling for database interactions.
+- Cache identity lookups and signing keys to reduce response times.
+

--- a/raodmap.md
+++ b/raodmap.md
@@ -1,0 +1,45 @@
+# Roadmap for Rust-based IdP
+
+## Overview
+This document outlines the development plan for a Rust-based Identity Provider (IdP) designed for low latency and strong security. The primary use case focuses on non-human identities such as agents, services, and automated clients.
+
+## Goals
+- **Latency:** Optimize request handling and token issuance to maintain sub-millisecond response times where possible.
+- **Security:** Use modern cryptographic primitives and minimize attack surface.
+- **Scalability:** Support thousands of concurrent identities and token operations.
+- **Automation:** Provide first-class APIs for non-human entities, including service accounts and agent authentication.
+
+## Phased Plan
+
+### Phase 1: Research & Requirements
+1. Gather detailed requirements for non-human identities.
+2. Evaluate existing Rust crates for OAuth2, JWT, and database layers.
+3. Determine preferred async runtime (Tokio or async-std).
+
+### Phase 2: Initial Prototype (MVP)
+1. Set up a basic HTTP server using **Axum** or **Actix Web**.
+2. Implement minimal token issuance using JWT for service accounts.
+3. Integrate a secure storage layer (e.g., PostgreSQL or SQLite for development).
+4. Create CLI utilities for managing service accounts.
+
+### Phase 3: Core Security & Persistence
+1. Harden JWT generation with rotating signing keys.
+2. Implement database migrations and migrations tooling.
+3. Introduce role-based access control for agents.
+4. Add audit logging for token operations.
+
+### Phase 4: Performance & Observability
+1. Add in-memory caching for frequent identity lookups.
+2. Benchmark response times and profile hot paths.
+3. Expose metrics (Prometheus) and tracing spans.
+
+### Phase 5: Feature Expansion
+1. Support OAuth2 client credentials flow for machine-to-machine auth.
+2. Provide token revocation and rotation APIs.
+3. Build SDK examples for common agent platforms.
+
+### Phase 6: Production Readiness
+1. Containerize the service using Docker.
+2. Provide CI/CD scripts for building and deploying the IdP.
+3. Write extensive integration tests and security fuzz tests.
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,107 @@
+use axum::{routing::post, Router, Json, extract::State};
+use clap::{Parser, Subcommand};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fs, path::PathBuf, sync::Arc};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run the IdP server
+    Server {
+        /// Path to accounts file
+        #[arg(long, default_value = "accounts.json")]
+        accounts: PathBuf,
+        /// Address to bind
+        #[arg(long, default_value = "127.0.0.1:3000")]
+        addr: String,
+    },
+    /// Create a new service account
+    CreateAccount {
+        /// Path to accounts file
+        #[arg(long, default_value = "accounts.json")]
+        accounts: PathBuf,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Account {
+    client_id: String,
+    client_secret: String,
+}
+
+type Accounts = Arc<Mutex<HashMap<String, String>>>;
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Server { accounts, addr } => {
+            let accounts_map = load_accounts(&accounts);
+            let state = Accounts::new(Mutex::new(accounts_map));
+            let app = Router::new().route("/token", post(issue_token)).with_state(state);
+            println!("Listening on {}", addr);
+            axum::Server::bind(&addr.parse().unwrap())
+                .serve(app.into_make_service())
+                .await
+                .unwrap();
+        }
+        Commands::CreateAccount { accounts } => {
+            let mut accounts_map = load_accounts(&accounts);
+            let id = Uuid::new_v4().to_string();
+            let secret = Uuid::new_v4().to_string();
+            accounts_map.insert(id.clone(), secret.clone());
+            save_accounts(&accounts, &accounts_map);
+            println!("Created account: {} {}", id, secret);
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct TokenRequest {
+    client_id: String,
+    client_secret: String,
+}
+
+#[derive(Serialize)]
+struct TokenResponse {
+    token: String,
+}
+
+async fn issue_token(State(accounts): State<Accounts>, Json(req): Json<TokenRequest>) -> Json<TokenResponse> {
+    let map = accounts.lock().await;
+    match map.get(&req.client_id) {
+        Some(secret) if secret == &req.client_secret => {
+            let claims = serde_json::json!({
+                "sub": req.client_id,
+                "exp": (chrono::Utc::now() + chrono::Duration::hours(24)).timestamp(),
+            });
+            let token = encode(&Header::default(), &claims, &EncodingKey::from_secret(b"secret"))
+                .unwrap();
+            Json(TokenResponse { token })
+        }
+        _ => Json(TokenResponse { token: "".into() }),
+    }
+}
+
+fn load_accounts(path: &PathBuf) -> HashMap<String, String> {
+    if let Ok(data) = fs::read_to_string(path) {
+        serde_json::from_str(&data).unwrap_or_default()
+    } else {
+        HashMap::new()
+    }
+}
+
+fn save_accounts(path: &PathBuf, map: &HashMap<String, String>) {
+    let data = serde_json::to_string_pretty(map).unwrap();
+    fs::write(path, data).unwrap();
+}
+

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,38 @@
+# Task Breakdown
+
+This file enumerates the major tasks required to design and implement the Rust-based IdP. Tasks are grouped by phase as outlined in the roadmap.
+
+## Phase 1: Research & Requirements
+- [ ] Document authentication needs for agents and services.
+- [ ] Compare Rust crates for web frameworks (Axum vs Actix Web).
+- [ ] Evaluate OAuth2 libraries and JWT signing crates.
+- [ ] Define performance targets and acceptable latency metrics.
+
+## Phase 2: Initial Prototype (MVP)
+- [ ] Set up repository with Cargo workspace and continuous integration.
+- [ ] Implement basic HTTP server exposing `/token` endpoint.
+- [ ] Store service account credentials in SQLite.
+- [ ] Provide a script/CLI to create new service accounts.
+
+## Phase 3: Core Security & Persistence
+- [ ] Integrate PostgreSQL and Diesel/SQLx for database access.
+- [ ] Implement rotating key management for JWT signing.
+- [ ] Add role-based permissions and simple policy checks.
+- [ ] Record all token issuance events to audit logs.
+
+## Phase 4: Performance & Observability
+- [ ] Introduce in-memory caching layer for identity lookups.
+- [ ] Profile request latency and optimize slow paths.
+- [ ] Export metrics and traces with Prometheus and OpenTelemetry.
+
+## Phase 5: Feature Expansion
+- [ ] Add OAuth2 client credentials flow with token revocation.
+- [ ] Provide API endpoints for token rotation and revocation.
+- [ ] Publish example SDKs or usage snippets for agents.
+
+## Phase 6: Production Readiness
+- [ ] Containerize the service and define Kubernetes/Docker deployment files.
+- [ ] Set up CI/CD pipeline for automated testing and releases.
+- [ ] Write integration tests covering authentication and edge cases.
+- [ ] Perform security audits and fuzz testing before release.
+


### PR DESCRIPTION
## Summary
- implement a small Rust service exposing a `/token` endpoint
- allow creation of service accounts via CLI
- expand README with build and run instructions

## Testing
- `cargo check` *(fails: Could not connect to crates.io)*
- `git status --short`
- `git log -1 --stat`
